### PR TITLE
Updating to use lens-5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,138 @@
+on:
+  # Build every pull request, to check for regressions.
+  pull_request:
+
+  # Build when a PR is merged, to update the README's CI badge.
+  push:
+#    branches: [main]
+
+name: build
+
+env:
+      CONFIG: --enable-benchmarks --enable-documentation --enable-tests --haddock-all --haddock-hyperlink-source --haddock-internal
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  # Run HLint to check for code improvements
+  hlint:
+    name: HLint Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: haskell/actions/setup@v1.1.5
+    - run: |
+        curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s app bench test lib -j
+
+
+  # Check that the project builds with the specified lower bounds.
+  lower-bounds:
+    env:
+      CONSTRAINTS: --project-file=lower-bounds.project
+    name: Lower Bounds Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: haskell/actions/setup@v1.1.5
+        name: Setup Haskell
+        with:
+          cabal-version: latest
+          ghc-version:   8.8.4
+
+      - run: cabal update
+      - run: cabal clean
+      - run: cabal configure $CONFIG $CONSTRAINTS
+      - run: cabal freeze    $CONFIG $CONSTRAINTS
+      - uses: actions/cache@v2
+        name: caching lower bounds check
+        with:
+          path: |
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-lower-bounds-${{ hashFiles('cabal.project.freeze') }}
+
+      - run: cabal build     $CONFIG $CONSTRAINTS --only-dependencies
+      - run: cabal build     $CONFIG $CONSTRAINTS
+
+
+  # Check that the project builds with the specified lower bounds.
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: haskell/actions/setup@v1.1.5
+        name: Setup Haskell
+        with:
+          cabal-version: latest
+          ghc-version:   latest
+
+      - run: cabal update
+      - run: cabal clean
+      - run: cabal configure --enable-tests --with-compiler=ghc
+      - run: cabal freeze    --enable-tests
+      - uses: actions/cache@v2
+        name: caching lower bounds check
+        with:
+          path: |
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-tests-${{ hashFiles('cabal.project.freeze') }}
+
+      - run: cabal test
+
+
+  # Cabal build matrix
+  cabal-build-matrix:
+    name: GHC-${{ matrix.ghc }}, cabal${{matrix.cabal}}, ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc:   [ '7.10.3', '8.0.2', '8.2.2', '8.4.4',' '8.6.5', '8.8.4', '8.10.4', '9.0.1' ]
+        cabal: [ 'latest']
+        os:    [ ubuntu-latest ]
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Setup Haskell
+        uses: haskell/actions/setup@v1.1.5
+        with:
+          ghc-version:   ${{ matrix.ghc   }}
+          cabal-version: ${{ matrix.cabal }}
+      - run: gcc    --version
+      - run: g++    --version
+      - run: ghc    --version
+      - run: cabal update
+      - run: cabal clean
+      - run: cabal configure $CONFIG --with-compiler=ghc
+      - run: cabal freeze    $CONFIG
+      - uses: actions/cache@v2
+        name: windows caching
+        with:
+          path: |
+            c:\sr
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          # restore keys is a fall back when the freeze plan is different
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+        if:  matrix.os == 'windows-latest'
+      - uses: actions/cache@v2
+        name: ubuntu-linux and osx caching
+        with:
+          path: |
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          # restore keys is a fall back when the freeze plan is different
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+        if:  matrix.os != 'windows-latest'
+      - run: cabal build --only-dependencies
+      - run: cabal build $CONFIG

--- a/changelog
+++ b/changelog
@@ -1,3 +1,12 @@
+1.2
+
+* Add Swap instance
+* Removed Swapped instance
+* Add support for GHC-9.0.*
+* Drop support for GHC-7.8.*, GHC-7.6.*, GHC-7.4.*, and GHC-7.2.*
+* Raise upper bounds on base and lens
+* Adjust lower bounds of most dependencies to be inline with the lowest supported GHC version of 7.10.3
+
 1.1
 
 * Generalise types of `validate` and `ensure` functions to use `Maybe` instead of `Bool`

--- a/examples/validation-examples.cabal
+++ b/examples/validation-examples.cabal
@@ -14,7 +14,7 @@ homepage:           https://github.com/qfpl/validation
 bug-reports:        https://github.com/qfpl/validation/issues
 cabal-version:      >= 1.10
 build-type:         Simple
-tested-with:        GHC==8.6.1, GHC==8.4.3, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:        GHC==9.0.1, GHC==8.10.4, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
 
 source-repository   head
   type:             git
@@ -29,8 +29,8 @@ executable validation-examples
 
   build-depends:
                       base          >= 4.5 && < 5
-                    , validation    >= 1   && < 1.2
-                    , lens          >= 4   && < 5
+                    , validation    >= 1   && < 1.3
+                    , lens          >= 4   && < 6
                     , bifunctors    >= 3   && < 6
 
   ghc-options:

--- a/lower-bounds.project
+++ b/lower-bounds.project
@@ -1,0 +1,15 @@
+constraints:
+  assoc         ==1.0.*,
+  base          ==4.8.*,
+  bifunctors    ==5.5.*,
+  deepseq       ==1.4.*,
+  ghc-prim      ==0.4.0.*,
+  hedgehog      ==0.5.*,
+  HUnit         ==1.5.*,
+  lens          ==4.*,
+  semigroupoids ==5.*,
+  semigroups    ==0.16.*
+
+packages: .
+
+

--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -44,11 +44,12 @@ import Control.Applicative(Applicative((<*>), pure), (<$>))
 import Control.DeepSeq (NFData (rnf))
 import Control.Lens (over, under)
 import Control.Lens.Getter((^.))
-import Control.Lens.Iso(Swapped(..), Iso, iso, from)
+import Control.Lens.Iso(Iso, iso, from)
 import Control.Lens.Prism(Prism, prism)
 import Control.Lens.Review(( # ))
 import Data.Bifoldable(Bifoldable(bifoldr))
 import Data.Bifunctor(Bifunctor(bimap))
+import Data.Bifunctor.Swap(Swap(..))
 import Data.Bitraversable(Bitraversable(bitraverse))
 import Data.Data(Data)
 import Data.Either(Either(Left, Right), either)
@@ -185,16 +186,10 @@ instance Monoid e => Monoid (Validation e a) where
     Failure mempty
   {-# INLINE mempty #-}
 
-instance Swapped Validation where
-  swapped =
-    iso
-      (\v -> case v of
-        Failure e -> Success e
-        Success a -> Failure a)
-      (\v -> case v of
-        Failure a -> Success a
-        Success e -> Failure e)
-  {-# INLINE swapped #-}
+instance Swap Validation where
+  swap (Failure e) = Success e
+  swap (Success a) = Failure a
+  {-# INLINE swap #-}
 
 instance (NFData e, NFData a) => NFData (Validation e a) where
   rnf v =

--- a/validation.cabal
+++ b/validation.cabal
@@ -1,5 +1,5 @@
 name:               validation
-version:            1.1
+version:            1.2
 license:            BSD3
 license-file:       LICENCE
 author:             Tony Morris <ʇǝu˙sıɹɹoɯʇ@ןןǝʞsɐɥ> <dibblego>, Nick Partridge <nkpart>
@@ -35,7 +35,7 @@ bug-reports:        https://github.com/qfpl/validation/issues
 cabal-version:      >= 1.10
 build-type:         Simple
 extra-source-files: changelog
-tested-with:        GHC==8.6.4, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:        GHC==9.0.1, GHC==8.10.4, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
 
 source-repository   head
   type:             git
@@ -46,12 +46,13 @@ library
                     Haskell2010
 
   build-depends:
-                      base          >= 4.5 && < 5
-                    , deepseq       >= 1.2 && < 1.5
-                    , semigroups    >= 0.8 && < 1
-                    , semigroupoids >= 5   && < 6
-                    , bifunctors    >= 5.1 && < 6
-                    , lens          >= 4   && < 5
+                      assoc         >= 1.0  && < 2
+                    , base          >= 4.5  && < 5
+                    , deepseq       >= 1.2  && < 1.5
+                    , semigroups    >= 0.8  && < 1
+                    , semigroupoids >= 5    && < 6
+                    , bifunctors    >= 5.1  && < 6
+                    , lens          >= 4    && < 6
   if impl(ghc>=7.2) && impl(ghc<7.5)
     build-depends: ghc-prim == 0.2.0.0
 
@@ -100,7 +101,7 @@ test-suite hunit
   build-depends:
                       base       >= 3   && < 5
                     , HUnit      >= 1.5 && < 1.7
-                    , lens       >= 4   && < 5
+                    , lens       >= 4   && < 6
                     , semigroups >= 0.8 && < 1
                     , validation
 

--- a/validation.cabal
+++ b/validation.cabal
@@ -35,7 +35,7 @@ bug-reports:        https://github.com/qfpl/validation/issues
 cabal-version:      >= 1.10
 build-type:         Simple
 extra-source-files: changelog
-tested-with:        GHC==9.0.1, GHC==8.10.4, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:        GHC==9.0.1, GHC==8.10.4, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3
 
 source-repository   head
   type:             git
@@ -47,14 +47,12 @@ library
 
   build-depends:
                       assoc         >= 1.0  && < 2
-                    , base          >= 4.5  && < 5
-                    , deepseq       >= 1.2  && < 1.5
-                    , semigroups    >= 0.8  && < 1
+                    , base          >= 4.8  && < 5
+                    , deepseq       >= 1.4  && < 1.5
+                    , semigroups    >= 0.16 && < 1
                     , semigroupoids >= 5    && < 6
-                    , bifunctors    >= 5.1  && < 6
+                    , bifunctors    >= 5.5  && < 6
                     , lens          >= 4    && < 6
-  if impl(ghc>=7.2) && impl(ghc<7.5)
-    build-depends: ghc-prim == 0.2.0.0
 
   ghc-options:
                     -Wall
@@ -76,9 +74,9 @@ test-suite hedgehog
                     Haskell2010
 
   build-depends:
-                      base       >= 3   && < 5
-                    , hedgehog   >= 0.5 && < 1.1
-                    , semigroups >= 0.8 && < 1
+                      base       >= 4.8  && < 5
+                    , hedgehog   >= 0.5  && < 1.1
+                    , semigroups >= 0.16 && < 1
                     , validation
 
   ghc-options:
@@ -99,10 +97,10 @@ test-suite hunit
                     Haskell2010
 
   build-depends:
-                      base       >= 3   && < 5
-                    , HUnit      >= 1.5 && < 1.7
-                    , lens       >= 4   && < 6
-                    , semigroups >= 0.8 && < 1
+                      base       >= 4.8  && < 5
+                    , HUnit      >= 1.5  && < 1.7
+                    , lens       >= 4    && < 6
+                    , semigroups >= 0.16 && < 1
                     , validation
 
   ghc-options:


### PR DESCRIPTION
This is a breaking change to use `lens-5` and make `validation` compatible with `ghc-9.0`. I bumped the version to `validation-1.2` as this would be a breaking change. `validation-1.1` would support pre-`ghc-.9.0` and `validation-1.2` would support `ghc-9.0` and potentially other versions moving forward.