### PR TITLE
Bump upper bounds for ghc-9.6.1.

### DIFF
--- a/examples/validation-examples.cabal
+++ b/examples/validation-examples.cabal
@@ -14,7 +14,7 @@ homepage:           https://github.com/qfpl/validation
 bug-reports:        https://github.com/qfpl/validation/issues
 cabal-version:      >= 1.10
 build-type:         Simple
-tested-with:        GHC==8.6.1, GHC==8.4.3, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:        GHC==8.6.1, GHC==8.4.3, GHC==8.2.2
 
 source-repository   head
   type:             git
@@ -28,10 +28,10 @@ executable validation-examples
                     Haskell2010
 
   build-depends:
-                      base          >= 4.5 && < 5
-                    , validation    >= 1   && < 1.2
-                    , lens          >= 4   && < 6
-                    , bifunctors    >= 3   && < 6
+                      base          >= 4.11 && < 5
+                    , validation    >= 1    && < 1.2
+                    , lens          >= 4    && < 6
+                    , bifunctors    >= 3    && < 6
 
   ghc-options:
                     -Wall

--- a/examples/validation-examples.cabal
+++ b/examples/validation-examples.cabal
@@ -30,7 +30,7 @@ executable validation-examples
   build-depends:
                       base          >= 4.5 && < 5
                     , validation    >= 1   && < 1.2
-                    , lens          >= 4   && < 5.1
+                    , lens          >= 4   && < 6
                     , bifunctors    >= 3   && < 6
 
   ghc-options:

--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -63,7 +63,7 @@ import Data.Functor(Functor(fmap))
 import Data.Functor.Alt(Alt((<!>)))
 import Data.Functor.Apply(Apply((<.>)))
 import Data.List.NonEmpty (NonEmpty)
-import Data.Monoid(Monoid(mappend, mempty))
+import Data.Monoid(Monoid(mempty))
 import Data.Ord(Ord)
 import Data.Semigroup(Semigroup((<>)))
 import Data.Traversable(Traversable(traverse))
@@ -175,9 +175,6 @@ instance Semigroup e => Semigroup (Validation e a) where
   {-# INLINE (<>) #-}
 
 instance Monoid e => Monoid (Validation e a) where
-  mappend =
-    appValidation mappend
-  {-# INLINE mappend #-}
   mempty =
     Failure mempty
   {-# INLINE mempty #-}

--- a/test/hedgehog_tests.hs
+++ b/test/hedgehog_tests.hs
@@ -2,7 +2,6 @@
 
 import Control.Applicative (liftA3)
 import Control.Monad (join, unless)
-import Data.Semigroup ((<>))
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range

--- a/validation.cabal
+++ b/validation.cabal
@@ -47,10 +47,10 @@ library
 
   build-depends:
                       base          >= 4.8  && < 5
-                    , assoc         >= 1    && < 1.1
+                    , assoc         >= 1    && < 2
                     , deepseq       >= 1.4  && < 1.5
                     , semigroups    >= 0.16 && < 1
-                    , semigroupoids >= 5    && < 6
+                    , semigroupoids >= 5    && < 7
                     , bifunctors    >= 5.5  && < 6
                     , lens          >= 4    && < 6
 
@@ -75,7 +75,7 @@ test-suite hedgehog
 
   build-depends:
                       base       >= 4.8  && < 5
-                    , hedgehog   >= 0.5  && < 1.1
+                    , hedgehog   >= 0.5  && < 2
                     , semigroups >= 0.16 && < 1
                     , validation
 
@@ -99,7 +99,7 @@ test-suite hunit
   build-depends:
                       base       >= 4.8  && < 5
                     , HUnit      >= 1.5  && < 1.7
-                    , lens       >= 4    && < 5
+                    , lens       >= 4    && < 6
                     , semigroups >= 0.16 && < 1
                     , validation
 

--- a/validation.cabal
+++ b/validation.cabal
@@ -35,7 +35,7 @@ bug-reports:        https://github.com/qfpl/validation/issues
 cabal-version:      >= 1.10
 build-type:         Simple
 extra-source-files: changelog
-tested-with:        GHC==9.0.1, GHC==8.10.4, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3
+tested-with:        GHC==9.0.1, GHC==8.10.4, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
 
 source-repository   head
   type:             git
@@ -46,7 +46,7 @@ library
                     Haskell2010
 
   build-depends:
-                      base          >= 4.8  && < 5
+                      base          >= 4.11 && < 5
                     , assoc         >= 1    && < 2
                     , deepseq       >= 1.4  && < 1.5
                     , semigroups    >= 0.16 && < 1
@@ -74,7 +74,7 @@ test-suite hedgehog
                     Haskell2010
 
   build-depends:
-                      base       >= 4.8  && < 5
+                      base       >= 4.11 && < 5
                     , hedgehog   >= 0.5  && < 2
                     , semigroups >= 0.16 && < 1
                     , validation
@@ -97,7 +97,7 @@ test-suite hunit
                     Haskell2010
 
   build-depends:
-                      base       >= 4.8  && < 5
+                      base       >= 4.11  && < 5
                     , HUnit      >= 1.5  && < 1.7
                     , lens       >= 4    && < 6
                     , semigroups >= 0.16 && < 1


### PR DESCRIPTION
Also bump lower bounds so `ghc-8.4.1` as the minimum (happy to undo this if you wish). I didn't update the CI scripts but can do that too. Am familiar with [haskell/actions](https://github.com/haskell/actions).